### PR TITLE
Added some sketchy code to allow the bot to run on perl 2.0 and not die with a runtime error if there is no config file.

### DIFF
--- a/terminus-bot
+++ b/terminus-bot
@@ -26,10 +26,12 @@
 #
 
 # Don't comment this out. No, really.
-unless RUBY_VERSION.start_with? "1.9"
-  abort "Ruby version 1.9 is required."
+unless RUBY_VERSION.start_with? "1.9" or RUBY_VERSION.start_with? "2.0"
+  abort "Ruby version 1.9 or better is required."
 end
-
+unless FileTest.exists?("terminus-bot.conf")
+  abort "No config file found."
+end
 VERSION  = "Terminus-Bot v0.8"
 PID_FILE = "var/terminus-bot.pid"
 LICENSE  = "MIT"


### PR DESCRIPTION
Allowed starting with perl 2.0, though I don't know any better way to implement this. Also made it check to see if the config file exists instead of dying with a runtime error.

In case you couldn't figure it out, I don't know perl, I just needed
this to run on perl 2.0 and also noticed it throwing runtime errors.
