### PR TITLE
Added bundler support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem 'eventmachine'
+gem 'psych'
+gem 'em-http-request'
+gem 'json'
+gem 'htmlentities'
+gem 'dnsruby'
+gem 'em-whois'
+gem 'ruby-mpd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.3)
+    cookiejar (0.3.0)
+    dnsruby (1.53)
+    em-http-request (1.0.3)
+      addressable (>= 2.2.3)
+      cookiejar
+      em-socksify
+      eventmachine (>= 1.0.0.beta.4)
+      http_parser.rb (>= 0.5.3)
+    em-socksify (0.2.1)
+      eventmachine (>= 1.0.0.beta.4)
+    em-synchrony (1.0.3)
+      eventmachine (>= 1.0.0.beta.1)
+    em-whois (0.3.0)
+      em-synchrony
+      whois (= 2.7.0)
+    eventmachine (1.0.3)
+    htmlentities (4.3.1)
+    http_parser.rb (0.5.3)
+    json (1.7.7)
+    psych (2.0.0)
+    whois (2.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dnsruby
+  em-http-request
+  em-whois
+  eventmachine
+  htmlentities
+  json
+  psych

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ have encountered, as well as all of those everyone else tells us about.
 * gems (mandatory)
     * eventmachine
     * psych (included psych has UTF-8 bugs)
-* gems (for some scripts)
     * htmlentities
     * json
-    * psych 1.2.2
     * dnsruby (dns script)
     * em-http-request (http_client module and all scripts that use it)
     * em-whois (whois script)

--- a/terminus-bot
+++ b/terminus-bot
@@ -34,6 +34,9 @@ unless FileTest.exists?("terminus-bot.conf")
   abort "No config file found."
 end
 
+require 'rubygems'
+require 'bundler/setup'
+
 VERSION  = "Terminus-Bot v0.8"
 PID_FILE = "var/terminus-bot.pid"
 LICENSE  = "MIT"


### PR DESCRIPTION
Terminus-Bot now supports bundler as an automated way to install all its dependencies. Dependencies also updated in the README.md file to accurately represent what it needs.
