### PR TITLE
Update message.rb

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -25,7 +25,7 @@
 
 
 module Bot
-  INCOMING_REGEX = /^(:(?<prefix>((?<nick>[^!]+)!(?<user>[^@]+)@(?<host>[^ ]+)|[^ ]+)) )?((?<numeric>[0-9]{3})|(?<command>[^ ]+))( (?<destination>[^:][^ ]*))?( :(?<text>.*)| (?<parameters>.*))?$/
+  INCOMING_REGEX = /^(:(?<prefix>((?<nick>[^! ]+)!(?<user>[^@ ]+)@(?<host>[^ ]+)|[^ ]+)) )?((?<numeric>[0-9]{3})|(?<command>[^ ]+))( (?<destination>[^:][^ ]*))?( :(?<text>.*)| (?<parameters>.*))?$/
 
   class Message
 


### PR DESCRIPTION
Fixed an issue that caused the Regex pattern to incorrectly parse Numerics such as this: 

:pinkiepie.ponychat.net 333 Jayden1 #test Caerdwyn!Tia@silhouetted.against.the.night.sky 1377275085

The "Numeric" group would match the first 3 digits of the Epoch seconds at the end of the line.
