### PR TITLE
Small updates to scripts/rss

### DIFF
--- a/scripts/rss.rb
+++ b/scripts/rss.rb
@@ -132,7 +132,7 @@ helpers do
       val.each do |feed|
         next if feed == nil
 
-        $log.debug("rss.check_feeds") { "Checking %s for %s on %s" % [feed, channel, network] }
+        $log.info("rss.check_feeds") { "Checking %s for %s on %s" % [feed, channel, network] }
 
         Bot.http_get(URI(feed[0])) do |http|
           rss = RSS::Parser.parse(http.response)

--- a/terminus-bot.conf.dist
+++ b/terminus-bot.conf.dist
@@ -622,8 +622,7 @@ relay = {
 # RSS/ATOM feed reader script.
 rss = {
 
-  # Interval (in seconds) to check for new feed items. This is approximate, since
-  # checks are triggered by server pings.
+  # Interval (in seconds) to check for new feed items.
   # default: 1800
   #interval = 1800
 


### PR DESCRIPTION
* Feed checks aren't based on receiving PINGs anymore, so remove that information from the distributed configuration file
* Log feed checks at INFO, the same level in-channel URL checks are logged at. Using the default interval of 30 minutes, this will be 48 log entries a day per feed.